### PR TITLE
Add missing import to avoid build failure

### DIFF
--- a/deepvariant/allelecounter_test.cc
+++ b/deepvariant/allelecounter_test.cc
@@ -31,6 +31,7 @@
 
 // UnitTests for allelecounter.{h,cc}.
 #include "deepvariant/allelecounter.h"
+#include <numeric>
 
 #include "deepvariant/utils.h"
 #include "third_party/nucleus/io/reference_fai.h"


### PR DESCRIPTION
Otherwise, build fails on gcc6 with the following error:
error: 'accumulate' is not a member of 'std'


