### PR TITLE
Fixed baseurl formatting, changed permalink for posts.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,3 +40,8 @@ plugins:
 #   - vendor/cache/
 #   - vendor/gems/
 #   - vendor/ruby/
+
+collections:
+  posts:
+    output: true
+    permalink: /posts/:path/

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
   {%- include head.html -%}
-  <link rel="shortcut icon" type="image/png" href="/assets/images/favicon.png">
+  <link rel="shortcut icon" type="image/png" href="{{ site.baseurl }}/assets/images/favicon.png">
 
   <body>
 

--- a/_posts/2018-12-05-improved-non-human-variant-calling-using-species-specific-deepvariant-models.markdown
+++ b/_posts/2018-12-05-improved-non-human-variant-calling-using-species-specific-deepvariant-models.markdown
@@ -24,7 +24,7 @@ calling accuracy by tuning DeepVariant for the new genome context. Finally, we
 generate a model for accurate variant calling on low-coverage mosquito genomes
 and a corresponding variant callset.
 
-![figure1](/deepvariant/assets/images/MalariaGEN/figure1.png)
+![figure1]({{ site.baseurl }}/assets/images/MalariaGEN/figure1.png)
 
 **Figure 1**: Summary: retraining DeepVariant improves accuracy of variant
 calling in mosquito genomes.
@@ -164,7 +164,7 @@ sites do not generate candidate variants to be evaluated by the CNN). The
 presence of HOM_REF calls with mostly non-reference reads remained even when
 filtering to calls with genotype quality >= 20.
 
-![figure2](/deepvariant/assets/images/MalariaGEN/figure2.png)
+![figure2]({{ site.baseurl }}/assets/images/MalariaGEN/figure2.png)
 
 **Figure 2**: Allele depth fractions for each individual at the three common
 variant types.
@@ -173,7 +173,7 @@ To understand this phenomenon better, we examined individual sites that were
 confidently predicted as HOM_REF but composed of many non-reference reads. A
 representative example is shown in **Figure 3**.
 
-![figure3](/deepvariant/assets/images/MalariaGEN/figure3.png)
+![figure3]({{ site.baseurl }}/assets/images/MalariaGEN/figure3.png)
 
 **Figure 3**: A representative Mendelian violation. Reads from AD0231-C
 (mother), AD0232-C (father), and AD0234-C (child) are shown from top to bottom.
@@ -271,7 +271,7 @@ DeepVariant is also able to provide a higher reliability in its most confident c
 Variants with the highest quality scores from DeepVariant have a very low Mendelian violation rate
 (reaching less than 0.1%), while a batch of GATK4's most confident calls never achieve less than a ~1% Mendelian violation rate.
 
-![figure4](/deepvariant/assets/images/MalariaGEN/figure4.png)
+![figure4]({{ site.baseurl }}/assets/images/MalariaGEN/figure4.png)
 
 **Figure 4**: Number of variants and Mendelian violations curve for GATK4 and
 the DeepVariant mosquito-specific model.


### PR DESCRIPTION
- Removed hardcoding of `/deepvariant` and using `site.baseurl` instead
- Added baseurl onto `favicon.png` path
- Changed permalink structure for posts to be `/posts/<post-name>`