### PR TITLE
Add back the GitHub issue template for reporting problems

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem_report.md
+++ b/.github/ISSUE_TEMPLATE/problem_report.md
@@ -1,0 +1,27 @@
+---
+name: 'Problem encountered while running DeepVariant'
+about: 'Tell us what happened, so we can try to help'
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the issue:**
+(A clear and concise description of what the issue is.)
+
+**Setup**
+  - Operating system:
+  - DeepVariant version:
+  - Installation method (Docker, built from source, etc.):
+  - Type of data: (sequencing instrument, reference genome, anything special that is unlike the case studies?)
+
+**Steps to reproduce:**
+  - Command:
+  - Error trace: (if applicable)
+
+**Does the quick start test work on your system?**
+Please test with https://github.com/google/deepvariant/blob/r1.0/docs/deepvariant-quick-start.md.
+Is there any way to reproduce the issue by using the quick start?
+
+**Any additional context:**


### PR DESCRIPTION
This is from the DeepVariant team.
We are not taking pull requests at this time.