### PR TITLE
Replace Miniconda with Miniforge and remove Anaconda default channel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,8 @@ ARG DV_GPU_BUILD=0
 ARG VERSION=1.8.0
 ARG TF_ENABLE_ONEDNN_OPTS=1
 
-FROM continuumio/miniconda3 as conda_setup
-RUN conda config --add channels defaults && \
-    conda config --add channels bioconda && \
-    conda config --add channels conda-forge
+FROM condaforge/miniforge3:24.9.2-0 as conda_setup
+RUN conda config --add channels bioconda
 RUN conda create -n bio \
                     bioconda::bcftools=1.15 \
                     bioconda::samtools=1.15 \


### PR DESCRIPTION
Hello, I am not sure you can take this PR.

Anaconda `defaults` channel being used in DeepVariant container, which most institutes need license to use it.

Any possible you can remove it because `bioconda` channel should be enough to install `samtools` and `bcftools`.

Thanks.