### PR TITLE
perf: Speed up the small-model caller: call the model directly instead of `Model.predict()`

### DIFF
--- a/deepvariant/make_examples_options.py
+++ b/deepvariant/make_examples_options.py
@@ -790,7 +790,9 @@ _SMALL_MODEL_EMIT_ALL_CANDIDATES = flags.DEFINE_bool(
 _SMALL_MODEL_INFERENCE_BATCH_SIZE = flags.DEFINE_integer(
     'small_model_inference_batch_size',
     128,
-    'Sets the batch size used by the small model during inference.',
+    'Deprecated and ignored: the small model now runs each region in a single'
+    ' forward pass, so this batch size no longer affects inference. Retained'
+    ' for command-line compatibility.',
 )
 _SMALL_MODEL_VAF_CONTEXT_WINDOW_SIZE = flags.DEFINE_integer(
     'small_model_vaf_context_window_size',

--- a/deepvariant/small_model/inference.py
+++ b/deepvariant/small_model/inference.py
@@ -69,7 +69,17 @@ def passes_confidence_threshold(
 def classify(
     classifier: keras.Model, examples: np.ndarray, batch_size: int
 ) -> np.ndarray:
-  return classifier.predict(examples, batch_size=batch_size, verbose=0)
+  # batch_size (the deprecated --small_model_inference_batch_size) is ignored:
+  # each region's candidates are run in a single forward pass.
+  del batch_size
+  # Call the model directly rather than via Model.predict(). predict() rebuilds
+  # a data adapter, callback list, and prediction loop on every invocation;
+  # because the small model is called once per region on a small batch, that
+  # per-call scaffolding -- not the arithmetic -- dominates its runtime.
+  # __call__ runs the same (cached) forward pass without that overhead. The
+  # result is numerically identical here: the model is a plain Dense MLP with no
+  # train/inference-divergent layers (e.g. BatchNorm or Dropout).
+  return np.asarray(classifier(examples, training=False))
 
 
 class SmallModelVariantCaller:

--- a/deepvariant/small_model/inference_test.py
+++ b/deepvariant/small_model/inference_test.py
@@ -29,6 +29,7 @@
 from unittest import mock
 from absl.testing import absltest
 from absl.testing import parameterized
+import numpy as np
 import tensorflow as tf
 from deepvariant.protos import deepvariant_pb2
 from deepvariant.small_model import inference
@@ -85,7 +86,9 @@ class SmallModelVariantCallerTest(parameterized.TestCase):
   def setUp(self):
     super().setUp()
     self.mock_classifier = mock.MagicMock()
-    self.mock_classifier.predict.return_value = [
+    # `classify` invokes the model directly (classifier(...)), so stub __call__
+    # rather than .predict().
+    self.mock_classifier.return_value = [
         (0.0, 0.999, 0.0),
         (0.0, 0.0, 0.1),
         (0.0, 0.0, 0.999),
@@ -192,7 +195,7 @@ class SmallModelVariantCallerTest(parameterized.TestCase):
     with mock.patch.object(
         type(self.mock_classifier),
         "__call__",
-        lambda self, x, training: [
+        lambda self, x, training=False: [
             (0.0, 0.999, 0.0),
             (0.0, 0.0, 0.1),
         ],
@@ -254,6 +257,58 @@ class SmallModelVariantCallerTest(parameterized.TestCase):
     )
     self.assertLen(call_variant_outputs, 4)
     self.assertLen(candidates_not_called, 4)
+
+
+class ClassifyEquivalenceTest(parameterized.TestCase):
+  """`classify` calls the model directly; that must match Model.predict()."""
+
+  def _build_small_model(self, num_features: int = 70):
+    """Builds a minimal Dense + softmax MLP of the small model's general shape.
+
+    The predict()-vs-__call__ equivalence holds for any layer sizes (it is a
+    property of the forward pass, not the architecture), so a small network is
+    used for speed rather than the production layer widths. Weights are then
+    amplified so the softmax is peaked, making the arg-max decision meaningful
+    instead of noise from near-uniform untrained outputs.
+    """
+    keras = inference.keras
+    model = keras.Sequential([
+        keras.layers.Input(shape=(num_features,)),
+        keras.layers.Dense(32, activation="relu"),
+        keras.layers.Dense(16, activation="relu"),
+        keras.layers.Dense(
+            len(make_small_model_examples.GenotypeEncoding),
+            activation="softmax",
+        ),
+    ])
+    for layer in model.layers:
+      weights = layer.get_weights()
+      if weights:
+        layer.set_weights([w * 5.0 for w in weights])
+    return model
+
+  @parameterized.parameters(1, 2, 7, 64, 128, 300)
+  def test_classify_matches_predict(self, num_candidates: int):
+    num_features = 70
+    model = self._build_small_model(num_features)
+    rng = np.random.default_rng(num_candidates)
+    # Integer features, exactly as encode_inference_examples produces them.
+    examples = rng.integers(
+        0, 100, size=(num_candidates, num_features)
+    ).astype(np.int64)
+
+    expected = model.predict(examples, batch_size=128, verbose=0)
+    actual = inference.classify(model, examples, batch_size=128)
+
+    self.assertEqual(actual.shape, expected.shape)
+    self.assertEqual(actual.dtype, expected.dtype)
+    # classify() runs the identical forward graph as predict() (same weights, no
+    # train/inference-divergent layers), so the shape, dtype, and every genotype
+    # arg-max decision are preserved; the probabilities also match to sub-ULP.
+    np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+    np.testing.assert_array_equal(
+        np.argmax(actual, axis=1), np.argmax(expected, axis=1)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

When `--call_small_model_examples` is enabled, `make_examples` runs a small Keras MLP once **per region** to pre-call easy candidates. That inference went through `keras.Model.predict()`, which rebuilds a data adapter, a `CallbackList`, and the prediction loop on **every** call. For the tiny per-region batches the small model sees, that per-call scaffolding — not the arithmetic — dominates its runtime.

This replaces the `predict()` call with a direct model call, which runs the same cached forward pass without the per-call machinery:

```python
# deepvariant/small_model/inference.py
def classify(classifier, examples, batch_size):
  del batch_size  # each region's candidates run in a single forward pass
  return np.asarray(classifier(examples, training=False))
```

## Why it's output-preserving

The small model is a plain `Dense` MLP ending in `softmax`, with **no** train/inference-divergent layers (no BatchNorm, no Dropout), so `__call__(training=False)` and `predict()` compute the identical forward pass over the same weights. The downstream gating (`passes_confidence_threshold` → `_accept_call_result`) consumes the same probability rows, so every genotype decision is preserved.

A new test (`ClassifyEquivalenceTest`) builds a `Dense`+`softmax` MLP of the small model's shape and asserts `classify()` matches `model.predict()` — same shape, same dtype, identical arg-max, probabilities `allclose` to 1e-6 — across batch sizes from 1 to 300 (i.e. spanning `predict`'s internal 128-row batching boundary).

### Verified on the production models over every real chr20 example

As a direct check (not just the synthetic unit test), `classify()` was instrumented to run **both** `predict()` and `__call__()` on every batch, using the real production `model.keras`, across all of chr20:

| model | examples compared | genotype-call (arg-max) changes | bit-identical probabilities | max prob diff | max GQ (phred) diff |
|---|---|---|---|---|---|
| WGS    | 222,978 | **0** | 100.0000% | 0 | 0 |
| PacBio | 299,227 | **0** | 99.9983% (5 rows differ) | 1.19e-07 | 2.8e-04 |
| ONT    | 482,232 | **0** | 99.9969% (15 rows differ) | 1.19e-07 | 8.7e-05 |

Across **>1,000,000 real candidate examples** the two paths produce **zero** genotype-call differences. WGS is bit-for-bit identical; on long-read data ~20 rows total differ by a single float32 ULP (1.19e-07) — an artifact of XLA choosing a slightly different matmul tiling for the larger long-read batches — but the resulting GQ difference is below 3e-4 phred, far too small to move any integer GQ threshold. So the change is decision-identical on real data.

(The per-call counts also explain the platform-dependent speedup: WGS made **44,133** `classify()` calls for its 222,978 rows (~5 rows/call), versus ~2,560 calls for PacBio/ONT (~120–190 rows/call). The per-call `predict()` overhead is paid ~17× more often on WGS, which is why WGS gains ~55% while long-read — where each call already amortizes the overhead over a large batch — gains little.)

## Measured impact (chr20, 16 shards, c8a.4xlarge / 16 cores)

`make_examples` wall time with `--call_small_model_examples`, 2 reps each:

| dataset | baseline (predict) | new (__call__) | speedup |
|---|---|---|---|
| WGS (Illumina)   | 231.8 / 231.7 s | 104.7 / 105.0 s | **−54.8%** |
| PacBio           | 142.4 / 142.3 s | 132.7 / 133.5 s | −6.6% |
| ONT              | 222.9 / 227.8 s | 213.0 / 233.4 s | ~−1–4% (within run noise) |

The WGS gain is large because short-read per-region work is cheap, so the fixed per-region `predict()` overhead dominated `make_examples`. Long-read pileup work dominates PacBio/ONT, so the same overhead is a smaller fraction — never a regression.

Output is unchanged: `examples_written` and the number of small-model calls are **identical** between baseline and new on all three datasets (WGS 79759 / 143219, PacBio 125483 / 173744, ONT 134755 / 347477); the compressed CVO output differs only within the run-to-run non-determinism floor.

## Notes

- Because each region now runs in a single forward pass, `--small_model_inference_batch_size` no longer affects inference. Its help text is updated to mark it deprecated/ignored, but the flag is **retained for command-line compatibility** (no removal, no breakage).

## Files

- `deepvariant/small_model/inference.py` — `classify()` uses `__call__`.
- `deepvariant/small_model/inference_test.py` — stub `__call__` instead of `.predict`; add the equivalence test.
- `deepvariant/make_examples_options.py` — deprecate the now-inert batch-size flag's help text.

